### PR TITLE
changing the base Dockerfile that's built to use cloudfoundry/cflinux…

### DIFF
--- a/buildpacker.go
+++ b/buildpacker.go
@@ -17,7 +17,7 @@ const (
 	BuildDir        = "code"
 	BuildpackDir    = "buildpack"
 	BuildpackZip    = "bp.zip"
-	DefaultBox      = "ubuntu"
+	DefaultBox      = "cloudfoundry/cflinuxfs2"
 	certFileFormat  = "%s/cert.pem"
 	keyFileFormat   = "%s/key.pem"
 	caFileFormat    = "%s/ca.pem"

--- a/fixtures/Dockerfile-valid
+++ b/fixtures/Dockerfile-valid
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM cloudfoundry/cflinuxfs2
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh 
 RUN apt-get install -y unzip curl ruby 
 RUN mkdir -p /var/buildpacker


### PR DESCRIPTION
…fs2 instead of the ubuntu base image.

Changes a pretty simple, but the general idea is that we could use the cloudfoundry base image instead of the Ubuntu base image in order to get us closer to the image which CF actually uses in the deployment environment.
